### PR TITLE
fix: allow self-transition on SMCTransition instantiation

### DIFF
--- a/lib/src/export/smc_transition.dart
+++ b/lib/src/export/smc_transition.dart
@@ -29,8 +29,7 @@ class SMCTransition {
   String? label;
   String? pseudoState;
 
-  SMCTransition({required this.from, required this.to})
-      : assert(from.name != to.name);
+  SMCTransition({required this.from, required this.to});
 
   /// A single [TransitionDefinition] can result in multiple transition lines.
   static List<SMCTransition> build(StateMachine stateMachine, SMCState owner,


### PR DESCRIPTION
Self-transitions are valid and I was able to generate a proper `smcat` and `svg` without this check.